### PR TITLE
The "set_cosmology" interface in model_hod

### DIFF
--- a/dark_emulator/model_hod/hod_interface.py
+++ b/dark_emulator/model_hod/hod_interface.py
@@ -125,7 +125,8 @@ class darkemu_x_hod(base_class):
         self.logdens_computed = False
 
     def set_cosmology(self, cparams):
-        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams.reshape(1, 6)) or (self.initialized == False):
+        cparams = cparams.reshape(1,6)
+        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
             self.do_linear_correction, cparams_tmp = cosmo_util.test_cosm_range(
                 cparams, return_edges=True)
             if cosmo_util.test_cosm_range_linear(cparams):

--- a/dark_emulator/model_hod/hod_interface.py
+++ b/dark_emulator/model_hod/hod_interface.py
@@ -126,7 +126,7 @@ class darkemu_x_hod(base_class):
 
     def set_cosmology(self, cparams):
         cparams = cparams.reshape(1,6)
-        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
+        if np.any(self.cosmo.get_cosmology() != cparams) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
             self.do_linear_correction, cparams_tmp = cosmo_util.test_cosm_range(
                 cparams, return_edges=True)
             if cosmo_util.test_cosm_range_linear(cparams):


### PR DESCRIPTION
Following the issue #11,  I have slightly modified the set_cosmology interface in the HOD module. Indeed, the tutorial notebook did not work when the newly specified cosmology is different from the previous one. This issue should have been resolved.