### PR TITLE
"grid=false" argument missed in the call of RectBivariateSpline in the getNoInterpol interface

### DIFF
--- a/dark_emulator/darkemu/auto.py
+++ b/dark_emulator/darkemu/auto.py
@@ -85,7 +85,7 @@ class auto_gp:
             s0 = 0
             xia0 = np.array([rbs(-self.logdens_list, -self.logdens_list,
                                  self.xih_mat[:, :, s0, i])(-logdens1, -logdens2, grid=False) for i in range(21)])
-            return xua0
+            return xia0
         elif sindex >= 20:
             s0 = 20
             xia0 = np.array([rbs(-self.logdens_list, -self.logdens_list,

--- a/dark_emulator/darkemu/auto.py
+++ b/dark_emulator/darkemu/auto.py
@@ -84,12 +84,12 @@ class auto_gp:
         if sindex <= 0:
             s0 = 0
             xia0 = np.array([rbs(-self.logdens_list, -self.logdens_list,
-                                 self.xih_mat[:, :, s0, i])(-logdens1, -logdens2) for i in range(21)])
+                                 self.xih_mat[:, :, s0, i])(-logdens1, -logdens2, grid=False) for i in range(21)])
             return xua0
         elif sindex >= 20:
             s0 = 20
             xia0 = np.array([rbs(-self.logdens_list, -self.logdens_list,
-                                 self.xih_mat[:, :, s0, i])(-logdens1, -logdens2) for i in range(21)])
+                                 self.xih_mat[:, :, s0, i])(-logdens1, -logdens2, grid=False) for i in range(21)])
             return xia0
         else:
             s0 = int(sindex)

--- a/dark_emulator/model_hod/hod_interface.py
+++ b/dark_emulator/model_hod/hod_interface.py
@@ -125,7 +125,8 @@ class darkemu_x_hod(base_class):
         self.logdens_computed = False
 
     def set_cosmology(self, cparams):
-        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams.reshape(1, 6)) or (self.initialized == False):
+        cparams = cparams.reshape(1,6)
+        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
             self.do_linear_correction, cparams_tmp = cosmo_util.test_cosm_range(
                 cparams, return_edges=True)
             if cosmo_util.test_cosm_range_linear(cparams):

--- a/dark_emulator/model_hod/hod_interface.py
+++ b/dark_emulator/model_hod/hod_interface.py
@@ -126,7 +126,7 @@ class darkemu_x_hod(base_class):
 
     def set_cosmology(self, cparams):
         cparams = cparams.reshape(1,6)
-        if np.any(self.cosmo.get_cosmology() != cparams.reshape(1, 6)) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
+        if np.any(self.cosmo.get_cosmology() != cparams) or np.any(self.cparams_orig != cparams) or (self.initialized == False):
             self.do_linear_correction, cparams_tmp = cosmo_util.test_cosm_range(
                 cparams, return_edges=True)
             if cosmo_util.test_cosm_range_linear(cparams):


### PR DESCRIPTION
This is a bug fix for #12.